### PR TITLE
Made dependencies less strict to support newer mongoid and rails versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,39 +1,47 @@
 PATH
   remote: .
   specs:
-    mongoid_translate (1.0.1)
-      activesupport (~> 3.1)
-      mongoid (~> 3.0)
+    mongoid_translate (1.0.2)
+      activesupport (>= 3.1)
+      mongoid (>= 3.0)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    activemodel (3.2.13)
-      activesupport (= 3.2.13)
-      builder (~> 3.0.0)
-    activesupport (3.2.13)
-      i18n (= 0.6.1)
-      multi_json (~> 1.0)
-    builder (3.0.4)
-    diff-lcs (1.1.3)
-    i18n (0.6.1)
-    mongoid (3.1.2)
-      activemodel (~> 3.2)
-      moped (~> 1.4.2)
-      origin (~> 1.0)
-      tzinfo (~> 0.3.22)
-    moped (1.4.4)
-    multi_json (1.7.2)
-    origin (1.0.11)
-    rspec (2.7.0)
-      rspec-core (~> 2.7.0)
-      rspec-expectations (~> 2.7.0)
-      rspec-mocks (~> 2.7.0)
-    rspec-core (2.7.1)
-    rspec-expectations (2.7.0)
-      diff-lcs (~> 1.1.2)
-    rspec-mocks (2.7.0)
-    tzinfo (0.3.37)
+    activemodel (4.2.5.2)
+      activesupport (= 4.2.5.2)
+      builder (~> 3.1)
+    activesupport (4.2.5.2)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
+    bson (4.0.4)
+    builder (3.2.2)
+    diff-lcs (1.2.5)
+    i18n (0.7.0)
+    json (1.8.3)
+    minitest (5.8.4)
+    mongo (2.2.4)
+      bson (~> 4.0)
+    mongoid (5.1.1)
+      activemodel (~> 4.0)
+      mongo (~> 2.1)
+      origin (~> 2.2)
+      tzinfo (>= 0.3.37)
+    origin (2.2.0)
+    rspec (2.99.0)
+      rspec-core (~> 2.99.0)
+      rspec-expectations (~> 2.99.0)
+      rspec-mocks (~> 2.99.0)
+    rspec-core (2.99.2)
+    rspec-expectations (2.99.2)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.99.4)
+    thread_safe (0.3.5)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
 
 PLATFORMS
   ruby
@@ -41,3 +49,6 @@ PLATFORMS
 DEPENDENCIES
   mongoid_translate!
   rspec (~> 2.6)
+
+BUNDLED WITH
+   1.11.2

--- a/mongoid_translate.gemspec
+++ b/mongoid_translate.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.files        = `git ls-files lib MIT-LICENSE README.md`.split("\n")
   s.platform     = Gem::Platform::RUBY
   s.require_path = 'lib'
-  s.add_dependency "activesupport",     "~>3.1"
-  s.add_dependency "mongoid",           "~>3.0"
-  s.add_development_dependency "rspec", "~>2.6"
+  s.add_dependency "activesupport",     ">= 3.1"
+  s.add_dependency "mongoid",           ">= 3.0"
+  s.add_development_dependency "rspec", "~> 2.6"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(path) unless $LOAD_PATH.include?(path)
 require 'mongoid_translate'
 
 Mongoid.configure do |config|
-  config.connect_to('mongoid_translate_spec', consistency: :strong)
+  config.connect_to('mongoid_translate_spec')
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
This pull request replaces the versions in some dependencies with a less strict range to support more rails and mongoid versions.
